### PR TITLE
Implement a module caching API

### DIFF
--- a/include/org_wasmer_Module.h
+++ b/include/org_wasmer_Module.h
@@ -39,6 +39,22 @@ JNIEXPORT jlong JNICALL Java_org_wasmer_Module_nativeInstantiate
 JNIEXPORT jboolean JNICALL Java_org_wasmer_Module_nativeValidate
   (JNIEnv *, jclass, jbyteArray);
 
+/*
+ * Class:     org_wasmer_Module
+ * Method:    nativeSerialize
+ * Signature: (J)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_org_wasmer_Module_nativeSerialize
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     org_wasmer_Module
+ * Method:    nativeDeserialize
+ * Signature: (Lorg/wasmer/Module;[B)J
+ */
+JNIEXPORT jlong JNICALL Java_org_wasmer_Module_nativeDeserialize
+  (JNIEnv *, jclass, jobject, jbyteArray);
+
 #ifdef __cplusplus
 }
 #endif

--- a/java/src/main/java/org/wasmer/Module.java
+++ b/java/src/main/java/org/wasmer/Module.java
@@ -5,6 +5,8 @@ class Module {
     private native void nativeDrop(long modulePointer);
     private native long nativeInstantiate(long modulePointer, Instance instance);
     private static native boolean nativeValidate(byte[] moduleBytes);
+    private native byte[] nativeSerialize(long modulePointer);
+    private static native long nativeDeserialize(Module module, byte[] serializedBytes);
 
     private long modulePointer;
 
@@ -21,6 +23,9 @@ class Module {
         this.modulePointer = modulePointer;
     }
 
+    private Module() {
+    }
+
     public void close() {
         this.nativeDrop(this.modulePointer);
     }
@@ -35,5 +40,16 @@ class Module {
         instance.instancePointer = instancePointer;
         instance.nativeInitializeExportedFunctions(instancePointer);
         return instance;
+    }
+
+    public byte[] serialize() {
+        return this.nativeSerialize(this.modulePointer);
+    }
+
+    public static Module deserialize(byte[] serializedBytes) {
+        Module module = new Module();
+        long modulePointer = Module.nativeDeserialize(module, serializedBytes);
+        module.modulePointer = modulePointer;
+        return module;
     }
 }

--- a/java/src/test/java/org/wasmer/ModuleTest.java
+++ b/java/src/test/java/org/wasmer/ModuleTest.java
@@ -53,4 +53,21 @@ class moduleTest {
 
         module.close();
     }
+
+    @Test
+    void serialize() throws IOException,Exception {
+        Module module = new Module(getBytes("tests.wasm"));
+        assertTrue(module.serialize() instanceof byte[]);
+    }
+
+    @Test
+    void deserialize() throws IOException,Exception {
+        Module module = new Module(getBytes("tests.wasm"));
+
+        byte[] serialized = module.serialize();
+        module = null;
+
+        Module deserializedModule = Module.deserialize(serialized);
+        assertEquals(3, (Integer) deserializedModule.instantiate().exports.get("sum").apply(1, 2)[0]);
+    }
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -10,7 +10,7 @@ use jni::{
 };
 use std::{panic, rc::Rc};
 use wasmer_runtime::{self as runtime, validate};
-use wasmer_runtime_core::imports;
+use wasmer_runtime_core::{cache::Artifact, imports, load_cache_with};
 
 pub struct Module {
     #[allow(unused)]
@@ -23,6 +23,44 @@ impl Module {
         let module_bytes = module_bytes.as_slice();
         let module = runtime::compile(module_bytes)
             .map_err(|e| runtime_error(format!("Failed to compile the module: {}", e)))?;
+
+        Ok(Self {
+            java_module_object,
+            module,
+        })
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, Error> {
+        match self.module.cache() {
+            Ok(artifact) => match artifact.serialize() {
+                Ok(serialized_artifact) => Ok(serialized_artifact),
+                Err(_) => {
+                    return Err(runtime_error(format!(
+                        "Failed to serialize the module artifact."
+                    )))
+                }
+            },
+            Err(_) => return Err(runtime_error(format!("Failed to get the module artifact."))),
+        }
+    }
+
+    fn deserialize(
+        java_module_object: GlobalRef,
+        serialized_module: Vec<u8>,
+    ) -> Result<Self, Error> {
+        let module = match Artifact::deserialize(serialized_module.as_slice()) {
+            Ok(artifact) => {
+                match unsafe { load_cache_with(artifact, &runtime::default_compiler()) } {
+                    Ok(module) => module,
+                    Err(_) => {
+                        return Err(runtime_error(format!(
+                            "Failed to compile the serialized module."
+                        )))
+                    }
+                }
+            }
+            Err(_) => return Err(runtime_error(format!("Failed to deserialize the module."))),
+        };
 
         Ok(Self {
             java_module_object,
@@ -98,6 +136,39 @@ pub extern "system" fn Java_org_wasmer_Module_nativeValidate(
             true => Ok(1),
             false => Ok(0),
         }
+    });
+
+    joption_or_throw(&env, output).unwrap_or(0)
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_wasmer_Module_nativeSerialize(
+    env: JNIEnv,
+    _class: JClass,
+    module_pointer: jptr,
+) -> jbyteArray {
+    let output = panic::catch_unwind(|| {
+        let module: &Module = Into::<Pointer<Module>>::into(module_pointer).borrow();
+        let serialized_module = module.serialize()?;
+        let java_serialized_module = env.byte_array_from_slice(serialized_module.as_slice())?;
+        Ok(java_serialized_module)
+    });
+
+    joption_or_throw(&env, output).unwrap_or(JObject::null().into_inner())
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_wasmer_Module_nativeDeserialize(
+    env: JNIEnv,
+    _class: JClass,
+    java_module: JObject,
+    java_serialized_module: jbyteArray,
+) -> jptr {
+    let output = panic::catch_unwind(|| {
+        let java_module_object = env.new_global_ref(java_module)?;
+        let serialized_module = env.convert_byte_array(java_serialized_module)?;
+        let module = Module::deserialize(java_module_object, serialized_module)?;
+        Ok(Pointer::new(module).into())
     });
 
     joption_or_throw(&env, output).unwrap_or(0)


### PR DESCRIPTION
Close #5 

In this PR, I added `serialize` and `deserialize` methods to skip compile a module. `deserialize` is a static method.
Users can use them by:
```
Module module = new Module(wasmBytes);
byte[] serialized = module.serialize();
module = null;
Module module2 = Module.deserialize(serialized);
Instance instance = module2.instantiate();
```